### PR TITLE
Disable pagination for all feed formats

### DIFF
--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -163,7 +163,17 @@ class MultipleFormatTemplateViewMixin(object):
     the url parameter of format.
     """
     template_name = None
-    available_formats = ['html', 'json', 'xml', 'rss', 'ics']
+    feed_formats = ['json', 'xml', 'rss', 'ics']
+    available_formats = ['html'] + feed_formats
+
+    def get_paginate_by(self, queryset):
+        """
+        Only paginate if the page is not a feed format.
+        """
+        if self.get_format() in self.feed_formats:
+            return None
+        else:
+            return self.paginate_by
 
     def get_format(self):
         """


### PR DESCRIPTION
This pull request fixes #2 by disabling pagination for calendar render formats that are used for feeds. The fix overrides [`get_paginate_by`](https://django-doc-test1.readthedocs.io/en/stable-1.6.x/ref/class-based-views/mixins-multiple-object.html#django.views.generic.list.MultipleObjectMixin.get_paginate_by) in `MultipleFormatTemplateViewMixin`.