### PR TITLE
Fixes bug where calendar editors are wiped out when a calendar's title is updated.

### DIFF
--- a/apps/events/forms/manager.py
+++ b/apps/events/forms/manager.py
@@ -67,8 +67,6 @@ class CalendarForm(ModelFormStringValidationMixin, ModelFormUtf8BmpValidationMix
     """
     Form for the Calendar
     """
-    editors = InlineLDAPSearchField(queryset=User.objects.none(), required=False)
-
     def __init__(self, *args, **kwargs):
         super(CalendarForm, self).__init__(*args, **kwargs)
         calendar = kwargs['instance']
@@ -86,7 +84,7 @@ class CalendarForm(ModelFormStringValidationMixin, ModelFormUtf8BmpValidationMix
 
     class Meta:
         model = Calendar
-        fields = ('title', 'description', 'editors')
+        fields = ('title', 'description')
 
 
 class CalendarSubscribeForm(forms.ModelForm):


### PR DESCRIPTION
It looks like CalendarForm was setting an editors field which was never in use on that form (it was likely added to that form before user and subscription editing were moved into different views).  This editors field would be set to empty any time the calendar was modified via the CalendarUpdate view, causing all editors on the calendar to be wiped out.

Fixes #4.