### PR TITLE
Redirect fix

### DIFF
--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -24,8 +24,6 @@ from core.utils import format_to_mimetype
 from core.utils import math_clamp
 from events.models import Calendar
 
-from haystack.views import SearchView
-
 log = logging.getLogger(__name__)
 
 

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -24,6 +24,8 @@ from core.utils import format_to_mimetype
 from core.utils import math_clamp
 from events.models import Calendar
 
+from haystack.views import SearchView
+
 log = logging.getLogger(__name__)
 
 
@@ -323,9 +325,9 @@ class SuccessPreviousViewRedirectMixin(object):
             """
             Avoid recursion bug on invalid form submissions--don't
             allow mixin logic to occur further in dynamically generated
-            views
+            views. Exclude for the search view
             """
-            if 'ignore_success_mixin' not in kwargs:
+            if 'ignore_success_mixin' not in kwargs and 'search' not in path:
                 kwargs['ignore_success_mixin'] = True
 
             if 'delete' not in self.request.path:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ python-dateutil==2.2
 python-ldap==2.4.14
 requests==2.1.0
 simplejson==3.3.2
-six==1.5.2
+six==1.9.0
 urllib3==1.7.1
 wsgiref==0.1.2


### PR DESCRIPTION
Bug Fixes:
* Updated redirect mixin not to add `ignore_redirect_mixin` kwarg for the search view. Fixes #13 , which actually didn't have anything to do with ending slashes.