### PR TITLE
Search result JSON feeds

### DIFF
--- a/apps/core/templatetags/core_tags.py
+++ b/apps/core/templatetags/core_tags.py
@@ -73,6 +73,21 @@ def static_ver(path):
         return url
 
 
+@register.simple_tag(takes_context=True)
+def absolute_uri_query_transform(context, **kwargs):
+    """
+    Takes a request and generates an absolute URL with given
+    kwargs as query parameters (updating existing param values
+    if present).
+    """
+    request = context['request']
+    updated = request.GET.copy()
+    for k, v in kwargs.items():
+        updated[k] = v
+
+    return request.build_absolute_uri('?' + updated.urlencode())
+
+
 @register.filter
 def parse_date(value):
     if isinstance(value, basestring):

--- a/apps/events/models/calendar.py
+++ b/apps/events/models/calendar.py
@@ -134,6 +134,18 @@ class Calendar(TimeCreatedModified):
                         })
         return canonical_root + relative_path
 
+    def get_json_details(self):
+        """
+        Generate a permalink to the single object details for this object
+        """
+        canonical_root = settings.CANONICAL_ROOT
+        relative_path = reverse('calendar', kwargs={
+            'pk': self.pk,
+            'slug': self.slug,
+            'format': 'json'
+        })
+        return canonical_root + relative_path
+
     def import_event(self, event):
         """
         Given an event, will duplicate that event and import it into this

--- a/apps/events/models/event.py
+++ b/apps/events/models/event.py
@@ -352,6 +352,20 @@ class Event(TimeCreatedModified):
         relative_path = reverse('event', kwargs={'pk': instance.pk, 'slug': self.slug})
         return canonical_root + relative_path
 
+    def get_json_details(self):
+        """
+        Generate a permalink to the single object details for this object
+        """
+        # Get the first event instance's pk
+        instance = self.get_first_instance
+        canonical_root = settings.CANONICAL_ROOT
+        relative_path = reverse('event', kwargs={
+            'pk': instance.pk,
+            'slug': self.slug,
+            'format': 'json'
+        })
+        return canonical_root + relative_path
+
     def __str__(self):
         return self.title
 

--- a/apps/events/views/search.py
+++ b/apps/events/views/search.py
@@ -1,18 +1,21 @@
 import logging
 
-from haystack.views import SearchView
+from haystack.generic_views import SearchView
 
+from core.views import MultipleFormatTemplateViewMixin
 from events.models import Event
 
 log = logging.getLogger(__name__)
 
 
-class GlobalSearchView(SearchView):
+class GlobalSearchView(MultipleFormatTemplateViewMixin, SearchView):
+    template_name = 'search/search.'
+    available_formats = ['html', 'json']
+
     """
     Only return unique events (do not return events copied to other calendars.)
     """
-    def get_results(self):
-        results = super(GlobalSearchView, self).get_results()
-        results = results.filter(created_from='None') # Yes, this has to be a string. Haystack will not return results by NoneType.
-
-        return results
+    def get_queryset(self):
+        queryset = super(GlobalSearchView, self).get_queryset()
+        queryset = queryset.filter(created_from='None') # Yes, this has to be a string. Haystack will not return results by NoneType
+        return queryset

--- a/apps/events/views/search.py
+++ b/apps/events/views/search.py
@@ -9,6 +9,7 @@ log = logging.getLogger(__name__)
 
 
 class GlobalSearchView(MultipleFormatTemplateViewMixin, SearchView):
+    paginate_by = 25
     template_name = 'search/search.'
     available_formats = ['html', 'json']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ clearcache-python==0.0.8
 django-appconf==0.6
 django-bleach==0.2.0
 django-compressor==1.3
-django-haystack==2.1.0
+django-haystack==2.4.1
 django-taggit==0.17.6
 django-widget-tweaks==1.3
 html2text==2014.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,20 @@
 beautifulsoup4==4.3.2
-Django==1.6.2
-MySQL-python==1.2.5
-Unidecode==0.04.19
 clearcache-python==0.0.8
+Django==1.6.2
 django-appconf==0.6
 django-bleach==0.2.0
 django-compressor==1.3
 django-haystack==2.4.1
 django-taggit==0.17.6
 django-widget-tweaks==1.3
+elasticsearch==1.9.0
 html2text==2014.7.3
 html5lib==0.999
 newrelic==2.20.1.18
 ordereddict==1.1
-# Note: Haystack 2.1.0 requires the unofficial pyelasticsearch package.
-# Haystack v2.1.1 should implement the official elasticsearch-py package.
-pyelasticsearch==0.6.1
 python-dateutil==2.2
 python-ldap==2.4.14
 requests==2.1.0
 simplejson==3.3.2
 six==1.9.0
-urllib3==1.7.1
-wsgiref==0.1.2
+urllib3==1.25.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ python-ldap==2.4.14
 requests==2.1.0
 simplejson==3.3.2
 six==1.9.0
-urllib3==1.25.8
+urllib3==1.23 # last supported version for python 2.6

--- a/templates/events/static/help.html
+++ b/templates/events/static/help.html
@@ -791,7 +791,7 @@
                 a completely custom application.
             </p>
             <p>
-                Feeds are available in JSON, RSS, XML, and ICS (iCal, Microsoft Outlook) formats.
+                Feeds are available in JSON, RSS, XML, and ICS (iCal, Microsoft Outlook) formats, unless otherwise noted.
             </p>
             <p>
                 All front-facing views (excluding the Year View) offer a feed of all the events data currently in that view.  Feeds
@@ -1197,6 +1197,38 @@
                             </td>
                             <td>
                                 n/a
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                              Search Results
+                              <p><small>
+                                  A list of event and calendars, ordered by relevance based on the provided query.
+                              </small></p>
+                              <p><small>
+                                <strong>Note:</strong> Search result feeds are currently only available in JSON format.
+                              </small></p>
+                            </td>
+                            <td><code>{% url 'haystack_search' format='json' %}</code></td>
+                            <td>
+                                n/a
+                            </td>
+                            <td>
+                                <ul class="table-list">
+                                  <li>
+                                    <code>q</code><br />
+                                    <small>Default: <em>None</em></small>
+                                  </li>
+                                  <li>
+                                    <code>page</code><br />
+                                    <small>Default: <em>1</em></small>
+                                  </li>
+                                  <li>
+                                    <code>models</code><br />
+                                    <small>Default: <em>(all models)</em></small><br />
+                                    <small>Options: <em>events.calendar</em>, <em>events.event</em></small>
+                                  </li>
+                                </ul>
                             </td>
                         </tr>
                     </tbody>

--- a/templates/search/search-result.json
+++ b/templates/search/search-result.json
@@ -1,0 +1,10 @@
+
+
+{
+    "object_type": "{{ result.model_name }}",
+    "object_id": "{{ item.pk }}",
+    "title": "{% if result.model_name == 'event' %}{{ item.get_title_canceled|escapejs }}{% else %}{{ item.title|escapejs }}{% endif %}",
+    "description": "{% if result.model_name == 'event' %}{{ item.description.strip|escapejs|default:FALLBACK_EVENT_DESCRIPTION }}{% else %}{{ item.description.strip|escapejs }}{% endif %}",
+    "url": "{{ item.get_absolute_url }}",
+    "details": "{{ item.get_json_details }}"
+}

--- a/templates/search/search-result.json
+++ b/templates/search/search-result.json
@@ -1,5 +1,3 @@
-
-
 {
     "object_type": "{{ result.model_name }}",
     "object_id": "{{ item.pk }}",

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -69,9 +69,9 @@
 
         <div class="row">
             <div class="col-md-12 page-content">
-                <p><em>{{ page.paginator.count }} result(s) found.</em></p>
+                <p><em>{{ page_obj.paginator.count }} result(s) found.</em></p>
                 {% if query %}
-                    {% with results=page.object_list %}
+                    {% with results=page_obj.object_list %}
                         {% if results %}
                             {% comment %}
                             Prioritize Main Calendar events. Assume that Main Calendar events

--- a/templates/search/search.json
+++ b/templates/search/search.json
@@ -3,4 +3,37 @@
 {% load core_tags %}
 {% load url %}
 
-TODO add json-y results here
+[
+{% if query %}
+    {% with results=page_obj.object_list %}
+        {% if results %}
+            {% comment %}
+            Prioritize Main Calendar events. Assume that Main Calendar events
+            will always be copied from somewhere else.
+
+            Events use the first instance's search-list-item.html esi template.
+            See esi/eventinstance/search-list-item.html for info.
+            {% endcomment %}
+
+            {% block results_list %}
+
+            {% for result in results %}
+                {% if result.model_name == 'calendar' %}
+                    {
+                        "todo": "todo"
+                    }
+                {% elif result.model_name == 'event' %}
+                    {% with object=result.object.get_main_event|default:result.object %}
+                        {
+                            "todo": "todo"
+                        }{% if not forloop.last %},{% endif %}
+                    {% endwith %}
+                {% endif %}
+            {% endfor %}
+
+            {% endblock %}
+
+        {% endif %}
+    {% endwith %}
+{% endif %}
+]

--- a/templates/search/search.json
+++ b/templates/search/search.json
@@ -1,36 +1,38 @@
 {% load core_tags %}
+{
+    "count": {{ page_obj.paginator.count }},
+    "next": "{% if page_obj.has_next %}{% absolute_uri_query_transform page=page_obj.next_page_number %}{% endif %}",
+    "previous": "{% if page_obj.has_previous %}{% absolute_uri_query_transform page=page_obj.previous_page_number %}{% endif %}",
+    "results": [
+        {% with results=page_obj.object_list %}
+            {% if results %}
 
-[
-{% if query %}
-    {% with results=page_obj.object_list %}
-        {% if results %}
+            {% comment %}
+            Prioritize Main Calendar events. Assume that Main Calendar events
+            will always be copied from somewhere else.
 
-        {% comment %}
-        Prioritize Main Calendar events. Assume that Main Calendar events
-        will always be copied from somewhere else.
+            Events use the first instance's search-list-item.html esi template.
+            See esi/eventinstance/search-list-item.html for info.
+            {% endcomment %}
 
-        Events use the first instance's search-list-item.html esi template.
-        See esi/eventinstance/search-list-item.html for info.
-        {% endcomment %}
+                {% block results_list %}
 
-            {% block results_list %}
+                {% for result in results %}
+                    {% if result.model_name == 'event' %}
+                        {% with item=result.object.get_main_event|default:result.object %}
+                        {% include 'search/search-result.json' %}
+                        {% endwith %}
+                    {% else %}
+                        {% with item=result.object %}
+                        {% include 'search/search-result.json' %}
+                        {% endwith %}
+                    {% endif %}
+                    {% if not forloop.last %},{% endif %}
+                {% endfor %}
 
-            {% for result in results %}
-                {% if result.model_name == 'event' %}
-                    {% with item=result.object.get_main_event|default:result.object %}
-                    {% include 'search/search-result.json' %}
-                    {% endwith %}
-                {% else %}
-                    {% with item=result.object %}
-                    {% include 'search/search-result.json' %}
-                    {% endwith %}
-                {% endif %}
-                {% if not forloop.last %},{% endif %}
-            {% endfor %}
+                {% endblock %}
 
-            {% endblock %}
-
-        {% endif %}
-    {% endwith %}
-{% endif %}
-]
+            {% endif %}
+        {% endwith %}
+    ]
+}

--- a/templates/search/search.json
+++ b/templates/search/search.json
@@ -1,34 +1,31 @@
-{% load widgets %}
-{% load widget_tweaks %}
 {% load core_tags %}
-{% load url %}
 
 [
 {% if query %}
     {% with results=page_obj.object_list %}
         {% if results %}
-            {% comment %}
-            Prioritize Main Calendar events. Assume that Main Calendar events
-            will always be copied from somewhere else.
 
-            Events use the first instance's search-list-item.html esi template.
-            See esi/eventinstance/search-list-item.html for info.
-            {% endcomment %}
+        {% comment %}
+        Prioritize Main Calendar events. Assume that Main Calendar events
+        will always be copied from somewhere else.
+
+        Events use the first instance's search-list-item.html esi template.
+        See esi/eventinstance/search-list-item.html for info.
+        {% endcomment %}
 
             {% block results_list %}
 
             {% for result in results %}
-                {% if result.model_name == 'calendar' %}
-                    {
-                        "todo": "todo"
-                    }
-                {% elif result.model_name == 'event' %}
-                    {% with object=result.object.get_main_event|default:result.object %}
-                        {
-                            "todo": "todo"
-                        }{% if not forloop.last %},{% endif %}
+                {% if result.model_name == 'event' %}
+                    {% with item=result.object.get_main_event|default:result.object %}
+                    {% include 'search/search-result.json' %}
+                    {% endwith %}
+                {% else %}
+                    {% with item=result.object %}
+                    {% include 'search/search-result.json' %}
                     {% endwith %}
                 {% endif %}
+                {% if not forloop.last %},{% endif %}
             {% endfor %}
 
             {% endblock %}

--- a/templates/search/search.json
+++ b/templates/search/search.json
@@ -1,0 +1,6 @@
+{% load widgets %}
+{% load widget_tweaks %}
+{% load core_tags %}
+{% load url %}
+
+TODO add json-y results here

--- a/urls.py
+++ b/urls.py
@@ -46,10 +46,7 @@ urlpatterns = patterns('',
 # Append search urls (this MUST go before Main Calendar overrides; else a 404 is returned on the haystack_search view!)
 if settings.SEARCH_ENABLED:
     urlpatterns += patterns('haystack.views',
-        url(r'^search/$', search_view_factory(
-            view_class=GlobalSearchView,
-            template='search/search.html'
-        ), name='haystack_search'),
+        url(r'^search/(?:feed\.(?P<format>[\w]+))?$', GlobalSearchView.as_view(), name='haystack_search'),
     )
 else:
     urlpatterns += patterns('',


### PR DESCRIPTION
Adds a JSON template for search results (events, calendars).  Individual search results use a consistent schema and provide a single object detail view link (`details`) for retrieving more information about the result.

This PR upgrades the django-haystack lib to v2.4.1 and utilizes its new class-based search view options, making it easy for us to extend the `GlobalSearchView` class with the `MultipleFormatTemplateViewMixin` like our other list-based object views that provide feeds.

Because django-haystack has been upgraded, its elasticsearch library requirement has changed from `pyelasticsearch` to `elasticsearch` v1.x.  To support the new elasticsearch library, urllib3 had to be upgraded as well (it requires urllib3 1.8+); its version number has been bumped to the last version that supports python 2.6.