### PR TITLE
Minor search feed updates

### DIFF
--- a/apps/events/urls/manager.py
+++ b/apps/events/urls/manager.py
@@ -142,7 +142,7 @@ urlpatterns += patterns('events.views.manager',
 # Search-related URLs
 if settings.SEARCH_ENABLED:
     urlpatterns += patterns('haystack.views',
-        url(r'^search/$', ManagerSearchView.as_view(), name='haystack_search_manager'),
+        url(r'^search/$', login_required(ManagerSearchView.as_view()), name='haystack_search_manager'),
     )
 else:
     urlpatterns += patterns('events.views.manager',

--- a/apps/events/urls/manager.py
+++ b/apps/events/urls/manager.py
@@ -30,7 +30,6 @@ from events.views.manager.tag import TagListView
 from events.views.manager.tag import TagUpdateView
 
 if settings.SEARCH_ENABLED:
-    from haystack.views import search_view_factory
     from events.views.manager.search import ManagerSearchView
 
 urlpatterns = patterns('',
@@ -143,10 +142,7 @@ urlpatterns += patterns('events.views.manager',
 # Search-related URLs
 if settings.SEARCH_ENABLED:
     urlpatterns += patterns('haystack.views',
-        url(r'^search/$', login_required(search_view_factory(
-            view_class=ManagerSearchView,
-            template='search/manager-search.html'
-        )), name='haystack_search_manager'),
+        url(r'^search/$', ManagerSearchView.as_view(), name='haystack_search_manager'),
     )
 else:
     urlpatterns += patterns('events.views.manager',

--- a/apps/events/views/manager/search.py
+++ b/apps/events/views/manager/search.py
@@ -8,6 +8,8 @@ log = logging.getLogger(__name__)
 
 
 class ManagerSearchView(SearchView):
+    template_name = 'search/manager-search.html'
+
     """
     Only return Event results that exist on the current user's
     calendars.

--- a/apps/events/views/manager/search.py
+++ b/apps/events/views/manager/search.py
@@ -1,6 +1,6 @@
 import logging
 
-from haystack.views import SearchView
+from haystack.generic_views import SearchView
 
 from events.models import Event
 
@@ -12,8 +12,8 @@ class ManagerSearchView(SearchView):
     Only return Event results that exist on the current user's
     calendars.
     """
-    def get_results(self):
-        results = super(ManagerSearchView, self).get_results()
+    def get_queryset(self):
+        results = super(ManagerSearchView, self).get_queryset()
         results = results.filter(calendar__in=self.request.user.calendars)
 
         return results

--- a/urls.py
+++ b/urls.py
@@ -16,7 +16,6 @@ from events.views.event_views import YearEventsListView
 from events.views.event_views import CalendarWidgetView
 
 if settings.SEARCH_ENABLED:
-    from haystack.views import search_view_factory
     from events.views.search import GlobalSearchView
 
 admin.autodiscover()


### PR DESCRIPTION
- Updated `ManagerSearchView` to use django-haystack's newer class-based SearchView.
- Removed no-longer-used `search_view_factory` imports
- Ensure `ManagerSearchView` requires a login to access, because that was apparently never added 🤷‍♀ 