### PR TITLE
Updated calendar add_update_user() role assignment logic

### DIFF
--- a/events/views/manager/calendar.py
+++ b/events/views/manager/calendar.py
@@ -217,13 +217,10 @@ def add_update_user(request, pk, username, role):
         user = get_object_or_404(User, username=username)
 
     get_role = request.GET.get('role', None)
-    if role is not None and role not in ['admin', 'editor']:
-        if get_role is not None and get_role in ['admin', 'editor']:
-            role = get_role
-        else:
-            role = None
-    else:
-        role = None
+    get_role = get_role if get_role in ['admin', 'editor'] else None
+    role = role if role in ['admin', 'editor'] else None
+    if role is None and get_role is not None:
+        role = get_role
 
     # Update user...
     if user == calendar.owner:


### PR DESCRIPTION
Fixed role assignment logic in the calendar `add_update_user()` view to fix a bug where demoting a user from admin to editor would return an invalid role assignment error.