### PR TITLE
Personal Information Audit

### DIFF
--- a/events/management/commands/audit-calendars.py
+++ b/events/management/commands/audit-calendars.py
@@ -3,6 +3,8 @@ import os
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User
+from django.db.models import Q
 
 from events.models import Calendar
 
@@ -11,7 +13,7 @@ class Command(BaseCommand):
         parser.add_argument(
             'audit',
             type=str,
-            help='The audit to run. Choices are: empty-calendars and invalid-names'
+            help='The audit to run. Choices are: empty-calendars, invalid-names and pii-in-title'
         )
 
         parser.add_argument(
@@ -29,6 +31,8 @@ class Command(BaseCommand):
             self.empty_calendars()
         elif self.audit_to_run == 'invalid-names':
             self.invalid_names()
+        elif self.audit_to_run == 'pii-in-title':
+            self.pii_in_titles()
         else:
             raise CommandError(f"{self.audit_to_run} is not a valid audit.")
 
@@ -83,6 +87,41 @@ CSV File exported to: {filepath}
 
                 stats = f"""
 Invalid Calendar Names Found: {inactive.count()}
+CSV File exported to: {filepath}
+        """
+
+        print(stats)
+
+    def pii_in_titles(self):
+        usernames = [x.username for x in User.objects.all()]
+        query = Q()
+
+        for username in usernames:
+            query = query | Q(title__istartswith=username.lower())
+
+        invalid = Calendar.objects.filter(query)
+
+        output = []
+        filepath = os.path.abspath(self.file)
+
+        for cal in invalid:
+            output.append({
+                'title': cal.title,
+                'owner_name': cal.owner.get_full_name() if cal.owner else None,
+                'owner_email': cal.owner.email if cal.owner else None
+            })
+
+        with open(self.file, 'w') as csv_file:
+            fieldnames = ['title', 'owner_name', 'owner_email']
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+
+            writer.writeheader()
+
+            for row in output:
+                writer.writerow(row)
+
+            stats = f"""
+NIDs In Title Found: {invalid.count()}
 CSV File exported to: {filepath}
         """
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds an audit for personal information in calendar titles. Currently, it only checks for calendars starting with a username. The results are not exact, as some usernames may be valid words that could appear at the beginning of a calendar title. The results will need to be checked and updated before using the list to communicate with users.

**Motivation and Context**
This audit will help us identify calendars which have title's that include usernames in them.

**How Has This Been Tested?**
The audit has been run in DEV and the results posted in Slack.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
