### PR TITLE
Added logic for redirecting tags not found

### DIFF
--- a/events/views/event_views.py
+++ b/events/views/event_views.py
@@ -7,6 +7,7 @@ from dateutil.relativedelta import relativedelta
 from django.db.models.query import QuerySet
 from django.http import Http404
 from django.http import HttpResponsePermanentRedirect
+from django.http.response import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.views.generic import DetailView
@@ -901,6 +902,14 @@ class EventsByTagList(PerPageOverrideMixin, InvalidSlugRedirectMixin, MultipleFo
     model = EventInstance
     paginate_by = 25
     template_name = 'events/frontend/tag/tag.'
+
+    def dispatch(self, request, *args, **kwargs):
+        try:
+            tag = Tag.objects.get(pk=kwargs['tag_pk'])
+            return super(EventsByTagList, self).dispatch(request, *args, **kwargs)
+        except Tag.DoesNotExist:
+            return HttpResponseRedirect(reverse('home'))
+
 
     def get_context_data(self, **kwargs):
         context = super(EventsByTagList, self).get_context_data()


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Updated the Events list view by tag to redirect to the home page if the Tag does not exist.

**Motivation and Context**
We want to make sure any tags are removed go somewhere instead of 404ing and have decided that having any not found tag go to the home page is an acceptable way to handle this.

**How Has This Been Tested?**
Changes can be viewed in DEV.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
