### PR TITLE
Support bulk posting of rereview events

### DIFF
--- a/events/models/event.py
+++ b/events/models/event.py
@@ -290,9 +290,8 @@ class Event(TimeCreatedModified):
         if self.created_from:
             # If main calendar copy then update everything except
             # the title and description and set for rereview
-            if self.calendar.is_main_calendar and self.state is not State.pending:
-                if is_main_rereview:
-                    self.state = State.rereview
+            if self.calendar.is_main_calendar and self.state is not State.pending and is_main_rereview:
+                self.state = State.rereview
             else:
                 self.title = self.created_from.title
                 self.description = self.created_from.description

--- a/events/views/manager/event.py
+++ b/events/views/manager/event.py
@@ -346,6 +346,12 @@ def update_event_state(request, pk=None, state=None):
     if not request.user.is_superuser and event.calendar not in request.user.calendars:
         messages.error(request, 'You cannot modify the state for Event %s.' % event.title)
     else:
+        # If manual review of rereview event changes was skipped via
+        # bulk update, assume that we want the incoming event data;
+        # ensure it gets copied over during this step:
+        if event.calendar.is_main_calendar and event.is_re_review and state is State.posted:
+            event.pull_updates()
+
         event.state = state
         try:
             event.save()


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added logic to ensure that, when a main calendar administrator/editor bulk-approves rereview events, or approves them via "Add to Posted" in the event's Actions dropdown in the dashboard, the original event's title and description are copied over (and are assumed to be "approved").

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current interface makes it pretty easy to skip copying over updated titles and descriptions from original events.  Doing this skips some quality control in favor of improved usability and to reduce the number of questions we get about missing updated event information from other users.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
