### PR TITLE
Added logic for fast-tracked approvals of trusted calendar events

### DIFF
--- a/events/models/calendar.py
+++ b/events/models/calendar.py
@@ -196,7 +196,10 @@ class Calendar(TimeCreatedModified):
         # Make state pending if copying for Main Calendar
         state = None
         if self.is_main_calendar:
-            state = events.models.State.pending
+            if event.calendar.trusted:
+                state = events.models.State.posted
+            else:
+                state = events.models.State.pending
         copy = event.copy(calendar=self, state=state)
         return copy
 

--- a/events/views/manager/event.py
+++ b/events/views/manager/event.py
@@ -144,7 +144,8 @@ class EventCreate(CreateView):
             if form.cleaned_data['submit_to_main']:
                 if self.object.state == State.posted:
                     get_main_calendar().import_event(self.object)
-                    messages.success(self.request, 'Event successfully submitted to the Main Calendar. Please allow 2-3 days for your event to be reviewed before it is posted to UCF\'s Main Calendar.')
+                    if not self.object.calendar.trusted:
+                        messages.success(self.request, 'Event successfully submitted to the Main Calendar. Please allow 2-3 days for your event to be reviewed before it is posted to UCF\'s Main Calendar.')
                 else:
                     messages.error(self.request, 'Event can not be submitted to the Main Calendar unless it is posted on your calendar.')
 
@@ -261,14 +262,16 @@ class EventUpdate(SuccessPreviousViewRedirectMixin, UpdateView):
             # Check if main calendar submission should be re-reviewed
             is_main_rereview = False
             if any(s in form.changed_data for s in ['description', 'title']):
-                is_main_rereview = True
+                if not self.object.calendar.trusted:
+                    is_main_rereview = True
 
             # Import to main calendar if posted, is requested and
             # is NOT already submitted to main calendar
             if not self.object.is_submit_to_main and form.cleaned_data['submit_to_main']:
                 if self.object.state == State.posted:
                     get_main_calendar().import_event(self.object)
-                    messages.success(self.request, 'Event successfully submitted to the Main Calendar. Please allow 2-3 days for your event to be reviewed before it is posted to UCF\'s Main Calendar.')
+                    if not self.object.calendar.trusted:
+                        messages.success(self.request, 'Event successfully submitted to the Main Calendar. Please allow 2-3 days for your event to be reviewed before it is posted to UCF\'s Main Calendar.')
                 else:
                     messages.error(self.request, 'Event can not be submitted to the Main Calendar unless it is posted on your calendar.')
             elif self.object.is_submit_to_main and self.object.state != State.posted and not self.object.calendar.is_main_calendar:


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Added the logic that fast-tracks events recommended for the main calendar on calendars that are `trusted`. This will ensure they're immediately posted, instead of going through the review process, and immediately updated, instead of going through the re-review process. Closes #142.

**Motivation and Context**
This will reduce the number of events that have to be reviewed on a regular basis by delegating authority to create events on the main calendar to trusted sources.

**How Has This Been Tested?**
Change is available in DEV.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
