### PR TITLE
Event preview

### DIFF
--- a/events/utils.py
+++ b/events/utils.py
@@ -80,6 +80,9 @@ def dedupe_instances_first_per_event(instance_queryset):
     Returns a list of the first instance of each
     instance set by parent event
     """
+    if instance_queryset.count() == 0:
+        return instance_queryset
+
     instances = instance_queryset.order_by().values('event__id').annotate(min_end=Min('end'))
     # Based off of example here:
     # https://stackoverflow.com/questions/14234971/django-queryset-to-return-first-of-each-item-in-foreign-key-based-on-date

--- a/events/views/manager/event.py
+++ b/events/views/manager/event.py
@@ -72,6 +72,17 @@ class EventCreate(CreateView):
 
         return ctx
 
+    def get_success_url(self, **kwargs):
+        if 'preview' in self.request.POST:
+            return reverse('events.views.event_views.event', kwargs = {
+                'pk': self.object.event_instances.first().pk,
+                'slug': self.object.event_instances.first().slug
+            })
+
+        return reverse('events.views.manager.dashboard-calendar-state', kwargs = {
+            'pk': self.object.calendar.pk
+        })
+
     def get(self, request, *args, **kwargs):
         """
         Handles the GET request and instantiates blank versions
@@ -102,6 +113,11 @@ class EventCreate(CreateView):
                 return HttpResponseForbidden('You cannot add an event to this calendar.')
 
             event = form.save(commit=False)
+
+            # If the preview button was clicked
+            if 'preview' in request.POST:
+                event.state = State.pending
+
             event_instance_formset = EventInstanceCreateFormSet(
                 data=self.request.POST,
                 instance=event

--- a/templates/events/frontend/event-single/event.html
+++ b/templates/events/frontend/event-single/event.html
@@ -41,7 +41,7 @@
           <a id="event-edit" class="d-none btn btn-sm btn-primary" href="{% url 'events.views.manager.event-update' pk=event_instance.event.pk %}">
             <span class="fa fa-pencil-alt fa-fw mr-1" aria-hidden="true"></span>Edit
           </a>
-          <a id="event-subscription" class="d-none object-modify btn btn-sm btn-default" href="{% url 'events.views.manager.event-copy' pk=event_instance.event.pk %}">
+          <a id="event-subscription" class="d-none object-modify btn btn-sm btn-info" href="{% url 'events.views.manager.event-copy' pk=event_instance.event.pk %}">
             <span class="fa fa-share pr-1" aria-hidden="true"></span>Add Event To
           </a>
         </div>

--- a/templates/events/frontend/event-single/event.html
+++ b/templates/events/frontend/event-single/event.html
@@ -41,7 +41,7 @@
           <a id="event-edit" class="d-none btn btn-sm btn-primary" href="{% url 'events.views.manager.event-update' pk=event_instance.event.pk %}">
             <span class="fa fa-pencil-alt fa-fw mr-1" aria-hidden="true"></span>Edit
           </a>
-          <a id="event-subscription" class="d-none object-modify btn btn-sm btn-inverse" href="{% url 'events.views.manager.event-copy' pk=event_instance.event.pk %}">
+          <a id="event-subscription" class="d-none object-modify btn btn-sm btn-default" href="{% url 'events.views.manager.event-copy' pk=event_instance.event.pk %}">
             <span class="fa fa-share pr-1" aria-hidden="true"></span>Add Event To
           </a>
         </div>

--- a/templates/events/frontend/event-single/event.html
+++ b/templates/events/frontend/event-single/event.html
@@ -29,6 +29,11 @@
     <h1 class="h2">{{ event_instance.event.get_title_canceled }}</h1>
   </div>
   <div class="edit-options col-lg-4 d-none mb-3 mb-lg-0 d-flex align-items-center justify-content-lg-end">
+    {% if event_instance.event.state == 0 %}
+    <a id="publish-event" class="d-none small font-weight-bold text-default-aw mr-3" href="{% url 'events.views.manager.event-post' pk=event_instance.event.pk %}">
+      <span class="fa fa-check-square mr-1" aria-hidden="true"></span>Publish
+    </a>
+    {% endif %}
     <a id="event-edit" class="d-none small font-weight-bold text-default-aw mr-3" href="{% url 'events.views.manager.event-update' pk=event_instance.event.pk %}">
       <span class="fa fa-pencil-alt fa-fw mr-1" aria-hidden="true"></span>Edit
     </a>
@@ -374,6 +379,7 @@ if(
   $('#event-single-title').attr('class', 'col-8');
   $('#page-title-wrap .edit-options').removeClass('d-none');
   $('#event-edit').removeClass('d-none');
+  $('#publish-event').removeClass('d-none');
 }
 
 // Show Add Event To button if user has calendars and the event isn't on their only calendar, or

--- a/templates/events/frontend/event-single/event.html
+++ b/templates/events/frontend/event-single/event.html
@@ -30,9 +30,9 @@
   </div>
   <div class="edit-options col-lg-4 d-none mb-3 mb-lg-0">
     <div class="card card-outline-secondary">
-      <div class="card-block">
-        <h2 class="text-center card-title h6">Admin Options</h2>
-        <div class="d-flex justify-content-between">
+      <div class="card-block text-center">
+        <h2 class="card-title h6">Admin Options</h2>
+        <div class="btn-group">
           {% if event_instance.event.state == 0 %}
           <a id="publish-event" class="d-none btn btn-sm btn-success" href="{% url 'events.views.manager.event-post' pk=event_instance.event.pk %}">
             <span class="fa fa-check-square mr-1" aria-hidden="true"></span>Publish

--- a/templates/events/frontend/event-single/event.html
+++ b/templates/events/frontend/event-single/event.html
@@ -28,18 +28,25 @@
   <div id="event-single-title" class="col-12">
     <h1 class="h2">{{ event_instance.event.get_title_canceled }}</h1>
   </div>
-  <div class="edit-options col-lg-4 d-none mb-3 mb-lg-0 d-flex align-items-center justify-content-lg-end">
-    {% if event_instance.event.state == 0 %}
-    <a id="publish-event" class="d-none small font-weight-bold text-default-aw mr-3" href="{% url 'events.views.manager.event-post' pk=event_instance.event.pk %}">
-      <span class="fa fa-check-square mr-1" aria-hidden="true"></span>Publish
-    </a>
-    {% endif %}
-    <a id="event-edit" class="d-none small font-weight-bold text-default-aw mr-3" href="{% url 'events.views.manager.event-update' pk=event_instance.event.pk %}">
-      <span class="fa fa-pencil-alt fa-fw mr-1" aria-hidden="true"></span>Edit
-    </a>
-    <a id="event-subscription" class="d-none object-modify small font-weight-bold text-default-aw" href="{% url 'events.views.manager.event-copy' pk=event_instance.event.pk %}">
-      <span class="fa fa-share pr-1" aria-hidden="true"></span>Add Event To
-    </a>
+  <div class="edit-options col-lg-4 d-none mb-3 mb-lg-0">
+    <div class="card card-outline-secondary">
+      <div class="card-block">
+        <h2 class="text-center card-title h6">Admin Options</h2>
+        <div class="d-flex justify-content-between">
+          {% if event_instance.event.state == 0 %}
+          <a id="publish-event" class="d-none btn btn-sm btn-success" href="{% url 'events.views.manager.event-post' pk=event_instance.event.pk %}">
+            <span class="fa fa-check-square mr-1" aria-hidden="true"></span>Publish
+          </a>
+          {% endif %}
+          <a id="event-edit" class="d-none btn btn-sm btn-primary" href="{% url 'events.views.manager.event-update' pk=event_instance.event.pk %}">
+            <span class="fa fa-pencil-alt fa-fw mr-1" aria-hidden="true"></span>Edit
+          </a>
+          <a id="event-subscription" class="d-none object-modify btn btn-sm btn-inverse" href="{% url 'events.views.manager.event-copy' pk=event_instance.event.pk %}">
+            <span class="fa fa-share pr-1" aria-hidden="true"></span>Add Event To
+          </a>
+        </div>
+      </div>
+    </div>
   </div>
 {% endblock %}
 

--- a/templates/events/manager/events/create_update.html
+++ b/templates/events/manager/events/create_update.html
@@ -404,6 +404,7 @@
             <a href="{% url 'dashboard' %}" class="btn btn-default">Cancel</a>
           {% else %}
             <button class="btn btn-primary" type="submit">Create Event</button>
+            <button id="preview" name="preview" class="btn btn-default" type="submit">Preview Event</button>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
- Adds a quick bug fix for the instance reducing logic added in #153.
- Adds a "Preview" button to the Event Create view that will save the event with the state of "Pending" and redirect the user to the detail view of unpublished event.
- Added the "Publish" button to the administrative actions that are visible when a user is logged in and has access to edit the event.
- Restyled the administrative actions into card with buttons.

**Motivation and Context**
The series of changes should make it possible for users to "preview" an event prior to publishing using existing logic by encouraging (through the additional "Preview" button) the saving of an event as pending, and then viewing the event prior to publishing. No new states needed to be created to accomplish this, and the addition of the publish button on the live view makes the workflow simpler. Closes #154.

**How Has This Been Tested?**
Changes are available for review on any pending event in DEV for superusers or pending events on any calendar a regular user is an admin on.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
