### PR TITLE
Add check for event state before showing publish button

### DIFF
--- a/events/urls/manager.py
+++ b/events/urls/manager.py
@@ -64,6 +64,7 @@ urlpatterns += [
     url(r'^event/(?P<pk>\d+)/pend', view=event.update_state, name='events.views.manager.event-pend', kwargs={'state':State.pending}),
     url(r'^event/(?P<pk>\d+)/cancel', view=event.cancel_uncancel, name='events.views.manager.event-cancel-uncancel'),
     url(r'^event/(?P<pk>\d+)/delete', login_required(EventDelete.as_view()), name='events.views.manager.event-delete'),
+    url(r'^event/(?P<pk>\d+)/state', login_required(event.get_event_state), name='events.views.manager.get-event-state'),
     url(r'^event/create', login_required(EventCreate.as_view()), name='events.views.manager.event-create'),
     url(r'^event/bulk-action/', view=event.bulk_action, name='events.views.manager.event-bulk-action'),
 

--- a/events/views/manager/event.py
+++ b/events/views/manager/event.py
@@ -1,10 +1,12 @@
 import logging
+import json
 from urllib.parse import quote_plus
 from urllib.parse import unquote_plus
 
 from django.http import Http404
 from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
+from django.http import HttpResponse
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
@@ -355,6 +357,23 @@ class EventDelete(SuccessPreviousViewRedirectMixin, DeleteSuccessMessageMixin, D
             return HttpResponseForbidden('You cannot delete the specified event.')
 
         return super(EventDelete, self).delete(request, *args, **kwargs)
+
+
+@login_required
+def get_event_state(request, pk=None):
+    """
+    Returns the state of the event along with the ID as JSON
+    """
+    event = get_object_or_404(Event, pk=pk)
+
+    data = {
+        'event_id': event.id,
+        'state': State.get_string(event.state)
+    }
+
+    retval = json.dumps(data)
+
+    return HttpResponse(retval, content_type='application/json')
 
 
 def update_event_state(request, pk=None, state=None):

--- a/templates/events/frontend/event-single/event.html
+++ b/templates/events/frontend/event-single/event.html
@@ -386,7 +386,14 @@ if(
   $('#event-single-title').attr('class', 'col-8');
   $('#page-title-wrap .edit-options').removeClass('d-none');
   $('#event-edit').removeClass('d-none');
-  $('#publish-event').removeClass('d-none');
+
+  var currentTime = Date.now();
+
+  $.getJSON("{% url 'events.views.manager.get-event-state' event_instance.event.pk %}?cb=" + currentTime, function(res) {
+    if (res.state === 'pending') {
+      $('#publish-event').removeClass('d-none');
+    }
+  });
 }
 
 // Show Add Event To button if user has calendars and the event isn't on their only calendar, or


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a small API call to the backend to check on an event's state before showing the publish button to logged in calendar owners/admins/editors.

**Motivation and Context**
This prevents the publish button from erroneously displaying after the event has been published.

**How Has This Been Tested?**
Changes are available for review in DEV.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
