### PR TITLE
Correct bug where the edit event view does not work

### DIFF
--- a/events/views/manager/event.py
+++ b/events/views/manager/event.py
@@ -198,7 +198,6 @@ class EventUpdate(SuccessPreviousViewRedirectMixin, UpdateView):
         Set the set of calendars the user can select from
         """
         initial = super(EventUpdate, self).get_initial()
-        initial['submit_to_calendar'] = self.get_object().get_copied_event().calendar
         if self.request.user.is_superuser:
             initial['user_calendars'] = Calendar.objects.active_calendars()
         else:


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Removes an unnecessary line of code that was causing an error to occur when trying to edit an existing event.

**Motivation and Context**
The logic that sets the initial value of the submit to calendar field is happening in the form class, and it being in a way that protects against a null reference error. This line of code is a hold over from us trying to figure things out and is not safely implemented or necessary.

**How Has This Been Tested?**
Changes are available in DEV for review. You should be able to open any existing event and not get an error.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
