### PR TITLE
Check to make sure the original event does not already exists before …

### DIFF
--- a/events/functions.py
+++ b/events/functions.py
@@ -3,6 +3,7 @@ import calendar as calgenerator
 from datetime import date
 import html
 
+from django.db.models import Q
 from django.core.exceptions import MultipleObjectsReturned
 
 from events.models import Event
@@ -32,7 +33,7 @@ def update_subscriptions(event, is_rereview=False):
         # Check to see if the event needs to be Created/Posted for any subscribed calendars
         for subscribed_calendar in event.calendar.subscribed_calendars.all():
             try:
-                copied = subscribed_calendar.events.get(created_from=original_event)
+                copied = subscribed_calendar.events.get(Q(created_from=original_event) | Q(pk=original_event.pk))
             except Event.DoesNotExist:
                 # Does not exist so import the event
                 subscribed_calendar.import_event(original_event)


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
An event copy loop was happening whenever a subscribed calendar recommended an event to the calendar it is subscribed to. For example, let's say Calendar A (a tier 3 calendar) is subscribed to Calendar B (a tier 2 calendar). Because it is subscribed, any new events created on Calendar B will be copied to Calendar A. If Calendar A creates an event and recommends it to Calendar B, that event will be copied to Calendar B and set to pending. The admin on Calendar B can then approve it, which will cause it to post on their calendar. Because Calendar A is subscribed to Calendar B, a copy of that event will be created on Calendar A, making an extra, unwanted copy of the event.

I have prevented this by checking to make sure the original event doesn't already exist on a calendar before making the copy.

**Motivation and Context**
We don't want the same event to show up twice on a calendar.

**How Has This Been Tested?**
Changes are in DEV and can be tested using the above example.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
