### PR TITLE
Added desktop and mobile fields for header images

### DIFF
--- a/events/forms/fields.py
+++ b/events/forms/fields.py
@@ -78,3 +78,6 @@ class CalendarChoiceField(forms.ModelChoiceField):
     """
     def valid_value(self, value):
         return True
+
+class CustomImageWidget(forms.widgets.ClearableFileInput):
+    template_name = 'widgets/custom-image-widget.html'

--- a/events/forms/manager.py
+++ b/events/forms/manager.py
@@ -12,6 +12,7 @@ from taggit.models import Tag
 from core.forms import RequiredModelFormSet
 from core.utils import generate_unique_slug
 from events.forms.fields import InlineLDAPSearchField
+from events.forms.fields import CustomImageWidget
 from events.forms.widgets import BootstrapSplitDateTimeWidget
 from events.forms.widgets import TaggitField
 from events.forms.widgets import Wysiwyg
@@ -98,7 +99,18 @@ class CalendarForm(ModelFormStringValidationMixin, ModelFormUtf8BmpValidationMix
 
     class Meta:
         model = Calendar
-        fields = ('title', 'description', 'active', 'trusted')
+        fields = (
+            'title',
+            'description',
+            'active',
+            'trusted',
+            'desktop_header_image',
+            'mobile_header_image',
+        )
+        widgets = {
+            'desktop_header_image': CustomImageWidget,
+            'mobile_header_image': CustomImageWidget
+        }
 
 
 class CalendarSubscribeForm(forms.ModelForm):

--- a/events/templates/widgets/custom-image-widget.html
+++ b/events/templates/widgets/custom-image-widget.html
@@ -1,0 +1,12 @@
+{% if widget.is_initial %}
+<div class="custom-image-field-widget">
+  <div>
+    <img class="custom-image-field-preview img-fluid" src="{{ widget.value.url }}" />
+  </div>
+  {% if not widget.required %}
+    <input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}"{% if widget.attrs.disabled %} disabled{% endif %}>
+    <label for="{{ widget.checkbox_id }}">Remove image</label>
+  {% endif %}
+</div>
+{% endif %}
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% include 'django/forms/widgets/attrs.html' %}>

--- a/templates/events/manager/calendar/update.html
+++ b/templates/events/manager/calendar/update.html
@@ -148,6 +148,37 @@
         </div>
         {% endif %}
 
+        {% if calendar.is_main_calendar %}
+        <div class="form-group row{% if form.desktop_header_image.errors %} has-danger{% endif %}">
+          <div class="col-md-3 col-xl-4 text-md-right mb-2">
+            <label class="font-weight-bold col-form-label pb-0" for="{{ form.desktop_header_image.auto_id }}">Desktop Header Image</label>
+            <small class="form-text text-muted mt-0">An optional 1600x500 pixel header image for the calendar.</small>
+          </div>
+          <div class="col-md-9 col-xl-8 d-md-flex flex-column justify-content-center">
+            {{ form.desktop_header_image|add_class:"form-control"|add_error_class:"form-control-danger" }}
+            {% if form.desktop_header_image.errors %}
+              {% for error in form.desktop_header_image.errors %}
+                <div class="form-control-feedback">{{ error }}</div>
+              {% endfor %}
+            {% endif %}
+          </div>
+        </div>
+        <div class="form-group row{% if form.mobile_header_image.errors %} has-danger{% endif %}">
+          <div class="col-md-3 col-xl-4 text-md-right mb-2">
+            <label class="font-weight-bold col-form-label pb-0" for="{{ form.mobile_header_image.auto_id }}">Mobile Header Image</label>
+            <small class="form-text text-muted mt-0">An optional 575x575 pixel header image for the calendar.</small>
+          </div>
+          <div class="col-md-9 col-xl-8 d-md-flex flex-column">
+            {{ form.mobile_header_image|add_class:"form-control"|add_error_class:"form-control-danger" }}
+            {% if form.mobile_header_image.errors %}
+              {% for error in form.mobile_header_image.errors %}
+                <div class="form-control-feedback">{{ error }}</div>
+              {% endfor %}
+            {% endif %}
+          </div>
+        </div>
+        {% endif %}
+
         {% for field in form.hidden_fields %}
           {{ field }}
         {% endfor %}


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's events system.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/unify-events/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Added basic file upload fields for the Desktop & Mobile Header Image fields.

**Motivation and Context**
We will want to be able to manage the header fields through the Calendar Info form field, so this adds the two fields to the form for the main calendar only. I'm not crazy about the default implementation of the ImageField widget, so I implemented a simple template override to the field to make it slightly better and more inline with out Athena styles.

**How Has This Been Tested?**
The changes are available for review in develop and the example links have been added to our Slack channel.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
